### PR TITLE
Improve security by removing .env from docker image layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /.data
 /dist
 /files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN sed -i 's/\r//g' /opt/wait-for-it.sh
 RUN sed -i 's/\r//g' /opt/startup.dev.sh
 
 WORKDIR /usr/src/app
-RUN rm -rf .env && cp env-example .env
+RUN cp env-example .env
 RUN npm run build
 
 CMD ["/bin/bash", "/opt/startup.dev.sh"]

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -13,7 +13,7 @@ RUN sed -i 's/\r//g' /opt/wait-for-it.sh
 RUN sed -i 's/\r//g' /opt/startup.ci.sh
 
 WORKDIR /usr/src/app
-RUN rm -rf .env && cp env-example .env
+RUN cp env-example .env
 RUN npm run build
 
 CMD ["/bin/bash", "/opt/startup.ci.sh"]


### PR DESCRIPTION
Although `RUN rm -rf .env` removes the file from the final layer, it may be still retrieved from the docker image intermediary layers.