### PR TITLE
Improved entrypoints by exiting if wait-for-it returns error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /usr/src/app
 RUN cp env-example .env
 RUN npm run build
 
-CMD ["/bin/bash", "/opt/startup.dev.sh"]
+CMD ["/opt/startup.dev.sh"]

--- a/e2e.Dockerfile
+++ b/e2e.Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /usr/src/app
 RUN cp env-example .env
 RUN npm run build
 
-CMD ["/bin/bash", "/opt/startup.ci.sh"]
+CMD ["/opt/startup.ci.sh"]

--- a/startup.ci.sh
+++ b/startup.ci.sh
@@ -1,4 +1,11 @@
-/opt/wait-for-it.sh postgres:5432 -- npm run migration:run && npm run seed:run
+#!/usr/bin/env bash
+set -e
+
+/opt/wait-for-it.sh postgres:5432
+npm run migration:run
+npm run seed:run
 npm run start:prod > /dev/null 2>&1 &
 /opt/wait-for-it.sh maildev:1080
-/opt/wait-for-it.sh localhost:3000 -- npm run lint && npm run test:e2e -- --runInBand
+/opt/wait-for-it.sh localhost:3000
+npm run lint
+npm run test:e2e -- --runInBand

--- a/startup.dev.sh
+++ b/startup.dev.sh
@@ -1,2 +1,7 @@
-/opt/wait-for-it.sh postgres:5432 -- npm run migration:run && npm run seed:run
+#!/usr/bin/env bash
+set -e
+
+/opt/wait-for-it.sh postgres:5432
+npm run migration:run
+npm run seed:run
 npm run start:prod


### PR DESCRIPTION
Before the entrypoint would run `/opt/wait-for-it.sh postgres:5432` and then run `npm run start:prod` regardless of the exit status of the `wait-for-it`
Now, not only the `start:prod` runs only when there's a connection to the DB, but also it takes a lot less seconds to notice the container fails because of the missing DB connection.

Also I just noticed a few issues with the Dockerfile. It's better to remove `/opt/wait-for-it.sh postgres:5432` from the entrypoint used in prod, because 
1. I doubt the hostname for postgres in prod will be `postgres`, hence that line will always fail
2. running migrations as part of the container startup script won't work if you want to scale your containers to two or more -- you'll most likely get race conditions when migrations are started in two containers simultaneously 