### PR TITLE
fix missing sessionId on refresh endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -104,7 +104,9 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt-refresh'))
   @HttpCode(HttpStatus.OK)
   public refresh(@Request() request): Promise<Omit<LoginResponseType, 'user'>> {
-    return this.service.refreshToken(request.user.sessionId);
+    return this.service.refreshToken({
+      sessionId: request.user.sessionId
+    });
   }
 
   @ApiBearerAuth()


### PR DESCRIPTION
Found a error in the session refresh implementation.

There's a missing "sessionId" variable in the auth.controller.ts refresh() function.