### PR TITLE
fix(auth): validateSocialLogin creates empty users without validation

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -140,7 +140,7 @@ export class AuthService {
       await this.usersService.update(user.id, user);
     } else if (userByEmail) {
       user = userByEmail;
-    } else {
+    } else if (socialData.id) {
       const role = {
         id: RoleEnum.user,
       };


### PR DESCRIPTION
Upon conducting a thorough examination of the /auth/facebook/login API endpoint within our authentication framework, a critical oversight was identified within the validateSocialLogin function's operational logic. Specifically, the function failed to adequately verify the validity and presence of the social identifier (socialData.id) received from social login attempts. This deficiency was revealed during a test scenario employing an intentionally malformed access token:

`{
  "accessToken": "randomWrongToken"
}`

The response from Facebook, indicating the access token's invalidity, was as follows:

`{
  "error": {
    "message": "Invalid OAuth access token - Cannot parse access token",
    "type": "OAuthException",
    "code": 190,
    "fbtrace_id": "A7rMyBlu_cueyOp2lH08Zfp"
  }
}
`

Despite this explicit error message, the validateSocialLogin method proceeded to create a new user record without ensuring the social login attempt was successful or even valid. This approach introduced a significant security risk, potentially allowing for the creation of user accounts without proper verification from the corresponding social login provider.

To address this vulnerability, a modification was proposed and implemented to introduce a validation checkpoint. This checkpoint ensures that a new user is only created if a valid social identifier (socialData.id) is present, thereby aligning the user creation process with successful authentication outcomes. This amendment significantly improves the security and integrity of the user authentication process, ensuring that new user records are only created following successful social login attempts.