### PR TITLE
fix(auth-twitter): Safeguard against undefined ID in Twitter auth response

### DIFF
--- a/src/auth-twitter/auth-twitter.service.ts
+++ b/src/auth-twitter/auth-twitter.service.ts
@@ -34,7 +34,7 @@ export class AuthTwitterService {
     });
 
     return {
-      id: data.id.toString(),
+      id: data.id?.toString(),
       email: data.email,
       firstName: data.name,
     };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -140,7 +140,7 @@ export class AuthService {
       await this.usersService.update(user.id, user);
     } else if (userByEmail) {
       user = userByEmail;
-    } else {
+    } else if (socialData.id) {
       const role = {
         id: RoleEnum.user,
       };


### PR DESCRIPTION
This commit addresses an issue within the `AuthTwitterService` where an attempt to call `toString()` on an undefined `id` would result in an error, particularly in scenarios where authentication fails and the Twitter API does not return an ID. By conditionally accessing the `id` property before invoking `toString()`, the service now gracefully handles cases where the authentication response lacks an `id`, thus enhancing the robustness of the Twitter authentication process and preventing runtime errors related to undefined values. This change ensures that the service can handle unsuccessful authentication attempts more reliably, avoiding potential disruptions in the authentication flow.
