### PR TITLE
Fixed emailAlreadyExists error in update function.

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -142,7 +142,7 @@ export class UsersService {
         email: clonedPayload.email,
       });
 
-      if (userObject?.id !== id) {
+      if (userObject && userObject.id !== id) {
         throw new HttpException(
           {
             status: HttpStatus.UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
# Error Message: emailAlreadyExists error when updating user mail address

## Issue:
When making a request to update the email address, even when using an email address that does not exist in the database, an "emailAlreadyExists" error is encountered.

## Code Modification:
The expression `userObject?.id !== id` has been changed to `userObject && userObject.id !== id`.

## Effect of the Change:
This modification allows for the resolution of the error and successful updating of the email address.

## Reasoning:
In the original code, an attempt was made to compare the id when `userObject` was null, leading to an error. With the modification, an error is thrown without attempting to compare if `userObject` is null.

 
 