### PR TITLE
fix: convert limit to number

### DIFF
--- a/src/utils/infinity-pagination.ts
+++ b/src/utils/infinity-pagination.ts
@@ -7,6 +7,6 @@ export const infinityPagination = <T>(
 ): InfinityPaginationResponseDto<T> => {
   return {
     data,
-    hasNextPage: data.length === options.limit,
+    hasNextPage: data.length === Number(options.limit),
   };
 };


### PR DESCRIPTION
Weird behavior coz `hasNext` always return false, i found out that `options.limit` return string since it is a strict equality i had to convert it to number.