### PR TITLE
feat(.env): allow environment variables to be passed dynamically to a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /.data
 /dist
 /files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN sed -i 's/\r//g' /opt/wait-for-it.sh
 RUN sed -i 's/\r//g' /opt/startup.relational.dev.sh
 
 WORKDIR /usr/src/app
-RUN if [ ! -f .env ]; then cp env-example-relational .env; fi
 RUN npm run build
 
 CMD ["/opt/startup.relational.dev.sh"]

--- a/docker-compose.document.yaml
+++ b/docker-compose.document.yaml
@@ -40,6 +40,7 @@ services:
       dockerfile: document.Dockerfile
     ports:
       - ${APP_PORT}:${APP_PORT}
-
+    env_file:
+      - .env
 volumes:
   boilerplate-mongo-db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - ${APP_PORT}:${APP_PORT}
-
+    env_file:
+      - .env
 volumes:
   boilerplate-db:

--- a/document.Dockerfile
+++ b/document.Dockerfile
@@ -16,7 +16,6 @@ RUN sed -i 's/\r//g' /opt/wait-for-it.sh
 RUN sed -i 's/\r//g' /opt/startup.document.dev.sh
 
 WORKDIR /usr/src/app
-RUN if [ ! -f .env ]; then cp env-example-document .env; fi
 RUN npm run build
 
 CMD ["/opt/startup.document.dev.sh"]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "typeorm": "env-cmd ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
+    "typeorm": "node typeorm-cli.js",
     "migration:generate": "npm run typeorm -- --dataSource=src/database/data-source.ts migration:generate",
     "migration:create": "npm run typeorm -- migration:create",
     "migration:run": "npm run typeorm -- --dataSource=src/database/data-source.ts migration:run",

--- a/typeorm-cli.js
+++ b/typeorm-cli.js
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+const child_process = require('child_process');
+
+const args = process.argv.slice(2).join(' ');
+
+let command;
+// Create the command to run TypeORM CLI with the provided arguments
+if (process.env.NODE_ENV === undefined) {
+  command = `env-cmd ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js ${args}`;
+} else {
+  command = `ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js ${args}`;
+}
+
+// Execute the command with the current environment variables
+child_process.execSync(command, { stdio: 'inherit', env: process.env });


### PR DESCRIPTION
In a production environment, keeping the environment variables inside the docker image is not recommended.
In production, we will most likely use Kubernetes or a container service like ECS where environment variables are passed dynamically to the container from a configmap or a secrets store. with the current configuration the dynamically passed environment  variables are overridden by the local .env file that was present during the build of the container.
when I removed the .env file from the docker file I noticed that TypeORM Cli wasn't working correctly because it uses "env-cmd" which requires a .env but isn't necessary in an environment where the variables are dynamic.
so I created a little script "typeorm-cli.js" that would run typeorm CLI with "env-cmd" when  needed and without it in a production environment such as kubernetes or ECS