### PR TITLE
fix: mongodb.ts file not removing mongoose-autopopulate library bug

### DIFF
--- a/.install-scripts/scripts/remove-mongodb.ts
+++ b/.install-scripts/scripts/remove-mongodb.ts
@@ -304,7 +304,7 @@ const removeMongoDb = async () => {
         replace: '',
       },
       {
-        find: /\s*\"mongoose\":.*/g,
+        find: /\s*\"mongoose(-autopopulate)?\":.*/g,
         replace: '',
       },
       {


### PR DESCRIPTION
When I select the postgres database, it leads to remove the mongodb related code, but I found that “mongoose-autopopulate”:“^1.1.0” in package.json is not removed.