### PR TITLE
Fixed Registration Bug: soft deleted user cannot re-register - throws unhandled error

### DIFF
--- a/src/database/migrations/1715028537217-CreateUser.ts
+++ b/src/database/migrations/1715028537217-CreateUser.ts
@@ -41,7 +41,7 @@ export class CreateUser1715028537217 implements MigrationInterface {
       `ALTER TABLE "user" ADD CONSTRAINT "FK_dc18daa696860586ba4667a9d31" FOREIGN KEY ("statusId") REFERENCES "status"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
     );
     await queryRunner.query(
-      `ALTER TABLE "session" ADD CONSTRAINT "FK_3d2f174ef04fb312fdebd0ddc53" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+      `ALTER TABLE "session" ADD CONSTRAINT "FK_3d2f174ef04fb312fdebd0ddc53" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );
   }
 

--- a/src/session/infrastructure/persistence/relational/entities/session.entity.ts
+++ b/src/session/infrastructure/persistence/relational/entities/session.entity.ts
@@ -21,6 +21,7 @@ export class SessionEntity extends EntityRelationalHelper {
 
   @ManyToOne(() => UserEntity, {
     eager: true,
+    onDelete: 'CASCADE',
   })
   @Index()
   user: UserEntity;

--- a/src/users/infrastructure/persistence/relational/repositories/user.repository.ts
+++ b/src/users/infrastructure/persistence/relational/repositories/user.repository.ts
@@ -82,6 +82,17 @@ export class UsersRelationalRepository implements UserRepository {
 
     return entity ? UserMapper.toDomain(entity) : null;
   }
+  
+  async findByEmailIncludingDeleted(email: User['email']): Promise<NullableType<User>> {
+    if (!email) return null;
+
+    const entity = await this.usersRepository.findOne({
+      withDeleted: true,
+      where: { email },
+    });
+
+    return entity ? UserMapper.toDomain(entity) : null;
+  }
 
   async findBySocialIdAndProvider({
     socialId,
@@ -122,5 +133,13 @@ export class UsersRelationalRepository implements UserRepository {
 
   async remove(id: User['id']): Promise<void> {
     await this.usersRepository.softDelete(id);
+  }
+  
+  async removePermanently(id: User['id']): Promise<void> {
+    await this.usersRepository.delete(id);
+  }
+
+  async restore(id: User['id']): Promise<void> {
+    await this.usersRepository.restore(id);
   }
 }

--- a/src/users/infrastructure/persistence/user.repository.ts
+++ b/src/users/infrastructure/persistence/user.repository.ts
@@ -23,6 +23,7 @@ export abstract class UserRepository {
   abstract findById(id: User['id']): Promise<NullableType<User>>;
   abstract findByIds(ids: User['id'][]): Promise<User[]>;
   abstract findByEmail(email: User['email']): Promise<NullableType<User>>;
+  abstract findByEmailIncludingDeleted(email: User['email']): Promise<NullableType<User>>;
   abstract findBySocialIdAndProvider({
     socialId,
     provider,
@@ -37,4 +38,6 @@ export abstract class UserRepository {
   ): Promise<User | null>;
 
   abstract remove(id: User['id']): Promise<void>;
+  abstract removePermanently(id: User['id']): Promise<void>;
+  abstract restore(id: User['id']): Promise<void>;
 }


### PR DESCRIPTION
Currently, a user cannot re-register after deletion. This is because a soft delete leaves the record, and the re-registration tries to create a record with an email that violates the unique key constraint. I add logic to handle in the user service by fully deleting the user, and then re-creating. This also requires modifying the on delete action for the Session entity. I added the ORM config and migration change to handle.