### PR TITLE
fix: error on relational with many to one

### DIFF
--- a/.hygen/property/add-to-relational/index.js
+++ b/.hygen/property/add-to-relational/index.js
@@ -199,6 +199,10 @@ module.exports = {
         }),
       );
 
+    if (!result.propertyInReference) {
+      result.propertyInReference = '';
+    }
+
     if (
       (result.kind === 'reference' || result.kind === 'duplication') &&
       result.referenceType === 'oneToMany'


### PR DESCRIPTION
Fix for CLI error on adding manyToOne relation in relational db structure.

```
Loaded templates: .hygen
ReferenceError: ejs:30
    28|     @ManyToOne(
    29|       () => <%= type %>Entity,
 >> 30|       <% if (propertyInReference) { -%>
    31|         (parentEntity) => parentEntity.<%= propertyInReference %>,
    32|       <% } -%>
    33|       { eager: <% if (propertyInReference) { -%>false<% } else { -%>true<% } -%>, nullable: <%= isNullable %> }

propertyInReference is not defined
```