### PR TITLE
Revert "fix: use mergeMap in ResolvePromisesInterceptor"

### DIFF
--- a/src/utils/serializer.interceptor.ts
+++ b/src/utils/serializer.interceptor.ts
@@ -5,12 +5,12 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import deepResolvePromises from './deep-resolver';
 
 @Injectable()
 export class ResolvePromisesInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    return next.handle().pipe(mergeMap((data) => deepResolvePromises(data)));
+    return next.handle().pipe(map((data) => deepResolvePromises(data)));
   }
 }


### PR DESCRIPTION
Reverts brocoders/nestjs-boilerplate#1997