### PR TITLE
fix: add readonly modifier to injected constructor parameters

### DIFF
--- a/src/auth-apple/auth-apple.service.ts
+++ b/src/auth-apple/auth-apple.service.ts
@@ -7,7 +7,7 @@ import { AllConfigType } from '../config/config.type';
 
 @Injectable()
 export class AuthAppleService {
-  constructor(private configService: ConfigService<AllConfigType>) {}
+  constructor(private readonly configService: ConfigService<AllConfigType>) {}
 
   async getProfileByToken(
     loginDto: AuthAppleLoginDto,

--- a/src/auth-facebook/auth-facebook.service.ts
+++ b/src/auth-facebook/auth-facebook.service.ts
@@ -11,7 +11,7 @@ export class AuthFacebookService {
   private readonly baseUrl = 'https://graph.facebook.com';
   private readonly apiVersion = 'v23.0';
 
-  constructor(private configService: ConfigService<AllConfigType>) {}
+  constructor(private readonly configService: ConfigService<AllConfigType>) {}
 
   /**
    * Retrieves a Facebook user profile using the provided access token.

--- a/src/auth-google/auth-google.service.ts
+++ b/src/auth-google/auth-google.service.ts
@@ -13,7 +13,7 @@ import { AllConfigType } from '../config/config.type';
 export class AuthGoogleService {
   private google: OAuth2Client;
 
-  constructor(private configService: ConfigService<AllConfigType>) {
+  constructor(private readonly configService: ConfigService<AllConfigType>) {
     this.google = new OAuth2Client(
       configService.get('google.clientId', { infer: true }),
       configService.get('google.clientSecret', { infer: true }),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,11 +32,11 @@ import { User } from '../users/domain/user';
 @Injectable()
 export class AuthService {
   constructor(
-    private jwtService: JwtService,
-    private usersService: UsersService,
-    private sessionService: SessionService,
-    private mailService: MailService,
-    private configService: ConfigService<AllConfigType>,
+    private readonly jwtService: JwtService,
+    private readonly usersService: UsersService,
+    private readonly sessionService: SessionService,
+    private readonly mailService: MailService,
+    private readonly configService: ConfigService<AllConfigType>,
   ) {}
 
   async validateLogin(loginDto: AuthEmailLoginDto): Promise<LoginResponseDto> {

--- a/src/database/mongoose-config.service.ts
+++ b/src/database/mongoose-config.service.ts
@@ -9,7 +9,7 @@ import mongooseAutoPopulate from 'mongoose-autopopulate';
 
 @Injectable()
 export class MongooseConfigService implements MongooseOptionsFactory {
-  constructor(private configService: ConfigService<AllConfigType>) {}
+  constructor(private readonly configService: ConfigService<AllConfigType>) {}
 
   createMongooseOptions(): MongooseModuleOptions {
     return {

--- a/src/database/seeds/relational/role/role-seed.service.ts
+++ b/src/database/seeds/relational/role/role-seed.service.ts
@@ -8,7 +8,7 @@ import { RoleEnum } from '../../../../roles/roles.enum';
 export class RoleSeedService {
   constructor(
     @InjectRepository(RoleEntity)
-    private repository: Repository<RoleEntity>,
+    private readonly repository: Repository<RoleEntity>,
   ) {}
 
   async run() {

--- a/src/database/seeds/relational/status/status-seed.service.ts
+++ b/src/database/seeds/relational/status/status-seed.service.ts
@@ -8,7 +8,7 @@ import { StatusEnum } from '../../../../statuses/statuses.enum';
 export class StatusSeedService {
   constructor(
     @InjectRepository(StatusEntity)
-    private repository: Repository<StatusEntity>,
+    private readonly repository: Repository<StatusEntity>,
   ) {}
 
   async run() {

--- a/src/database/seeds/relational/user/user-seed.service.ts
+++ b/src/database/seeds/relational/user/user-seed.service.ts
@@ -11,7 +11,7 @@ import { UserEntity } from '../../../../users/infrastructure/persistence/relatio
 export class UserSeedService {
   constructor(
     @InjectRepository(UserEntity)
-    private repository: Repository<UserEntity>,
+    private readonly repository: Repository<UserEntity>,
   ) {}
 
   async run() {

--- a/src/database/typeorm-config.service.ts
+++ b/src/database/typeorm-config.service.ts
@@ -5,7 +5,7 @@ import { AllConfigType } from '../config/config.type';
 
 @Injectable()
 export class TypeOrmConfigService implements TypeOrmOptionsFactory {
-  constructor(private configService: ConfigService<AllConfigType>) {}
+  constructor(private readonly configService: ConfigService<AllConfigType>) {}
 
   createTypeOrmOptions(): TypeOrmModuleOptions {
     return {

--- a/src/files/infrastructure/persistence/document/repositories/file.repository.ts
+++ b/src/files/infrastructure/persistence/document/repositories/file.repository.ts
@@ -13,7 +13,7 @@ import { NullableType } from '../../../../../utils/types/nullable.type';
 export class FileDocumentRepository implements FileRepository {
   constructor(
     @InjectModel(FileSchemaClass.name)
-    private fileModel: Model<FileSchemaClass>,
+    private readonly fileModel: Model<FileSchemaClass>,
   ) {}
 
   async create(data: Omit<FileType, 'id'>): Promise<FileType> {

--- a/src/home/home.controller.ts
+++ b/src/home/home.controller.ts
@@ -6,7 +6,7 @@ import { HomeService } from './home.service';
 @ApiTags('Home')
 @Controller()
 export class HomeController {
-  constructor(private service: HomeService) {}
+  constructor(private readonly service: HomeService) {}
 
   @Get()
   appInfo() {

--- a/src/home/home.service.ts
+++ b/src/home/home.service.ts
@@ -4,7 +4,7 @@ import { AllConfigType } from '../config/config.type';
 
 @Injectable()
 export class HomeService {
-  constructor(private configService: ConfigService<AllConfigType>) {}
+  constructor(private readonly configService: ConfigService<AllConfigType>) {}
 
   appInfo() {
     return { name: this.configService.get('app.name', { infer: true }) };

--- a/src/roles/roles.guard.ts
+++ b/src/roles/roles.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from '@nestjs/core';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(private readonly reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
     const roles = this.reflector.getAllAndOverride<(number | string)[]>(

--- a/src/session/infrastructure/persistence/document/repositories/session.repository.ts
+++ b/src/session/infrastructure/persistence/document/repositories/session.repository.ts
@@ -12,7 +12,7 @@ import { User } from '../../../../../users/domain/user';
 export class SessionDocumentRepository implements SessionRepository {
   constructor(
     @InjectModel(SessionSchemaClass.name)
-    private sessionModel: Model<SessionSchemaClass>,
+    private readonly sessionModel: Model<SessionSchemaClass>,
   ) {}
 
   async findById(id: Session['id']): Promise<NullableType<Session>> {


### PR DESCRIPTION
## ⚡ Fix: Add readonly to Injected Constructor Parameters

### Changes Made
- **Added `readonly` modifier to 18 constructor parameters across 14 files** that were missing it on injected dependencies

### Why
Constructor parameters for injected services should be `readonly` to prevent accidental reassignment. This is a [NestJS best practice](https://docs.nestjs.com/providers#dependency-injection) and enforced by tools like `nestjs-doctor` (`prefer-readonly-injection` rule).

### Breaking Changes
- None — `readonly` only prevents reassignment, it does not change behavior

### Detected with
[nestjs-doctor](https://github.com/RoloBits/nestjs-doctor) — static analysis for NestJS projects