### PR TITLE
fix: remove redundant ConfigModule import from HomeModule

### DIFF
--- a/src/home/home.module.ts
+++ b/src/home/home.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { HomeService } from './home.service';
 import { HomeController } from './home.controller';
-import { ConfigModule } from '@nestjs/config';
+
 
 @Module({
-  imports: [ConfigModule],
+
   controllers: [HomeController],
   providers: [HomeService],
 })


### PR DESCRIPTION
Fixes #2077

`ConfigModule` is already registered with `isGlobal: true` in `AppModule`,
making the explicit import in `HomeModule` redundant. Removed the unnecessary
import to keep the codebase clean and consistent with NestJS best practices.