### PR TITLE
Feat linter formatter choice

### DIFF
--- a/.install-scripts/index.ts
+++ b/.install-scripts/index.ts
@@ -11,6 +11,7 @@ import removeAllDbResourceGeneration from './scripts/resource-generation-scripts
 import removeAllDbPropertyGeneration from './scripts/property-generation-scripts/remove-all-db';
 import removeDocumentPropertyGeneration from './scripts/property-generation-scripts/remove-document';
 import removeRelationalPropertyGeneration from './scripts/property-generation-scripts/remove-relational';
+import removeEslintPrettier from './scripts/remove-eslint-prettier';
 
 void (async () => {
   const response = await prompts(
@@ -24,6 +25,16 @@ void (async () => {
           { title: 'PostgreSQL', value: 'pg' },
           { title: 'MongoDB', value: 'mongo' },
         ],
+      },
+      {
+        type: 'select',
+        name: 'linterFormatter',
+        message: 'Which linter and formatter do you want to use?',
+        choices: [
+          { title: 'ESLint & Prettier', value: 'eslint-prettier' },
+          { title: 'Biome', value: 'biome' },
+        ],
+        initial: 0,
       },
       {
         type: 'confirm',
@@ -72,6 +83,10 @@ void (async () => {
     removeDocumentPropertyGeneration();
     removeAllDbResourceGeneration();
     removeAllDbPropertyGeneration();
+  }
+
+  if (response.linterFormatter === 'biome') {
+    removeEslintPrettier();
   }
 
   if (!response.isAuthFacebook) {

--- a/.install-scripts/scripts/remove-eslint-prettier.ts
+++ b/.install-scripts/scripts/remove-eslint-prettier.ts
@@ -1,0 +1,147 @@
+import replace from '../helpers/replace';
+import path from 'path';
+import fs from 'fs';
+
+const removeEslintPrettier = () => {
+  replace({
+    path: path.join(process.cwd(), 'package.json'),
+    actions: [
+      {
+        find: /\s*\"@eslint\/eslintrc\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"@eslint\/js\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"@typescript-eslint\/eslint-plugin\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"@typescript-eslint\/parser\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"eslint\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"eslint-config-prettier\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"eslint-plugin-prettier\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"globals\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\s*\"prettier\":.*/g,
+        replace: '',
+      },
+      {
+        find: /\"format\": \"prettier --write \\\"src\/\*\*\/\*\.ts\\\" \\\"test\/\*\*\/\*\.ts\\\"\"/g,
+        replace:
+          '"format": "biome format --write src/ test/ .install-scripts/"',
+      },
+      {
+        find: /\"lint\": \"eslint \\\"\{src,apps,libs,test\}\/\*\*\/\*\.ts\\\"\"/g,
+        replace: '"lint": "biome check --write src/ test/ .install-scripts/"',
+      },
+      {
+        find: /npm run lint -- --fix/g,
+        replace: 'npm run lint',
+      },
+    ],
+  });
+
+  replace({
+    path: path.join(process.cwd(), 'package.json'),
+    actions: [
+      {
+        find: /(\s*\"@biomejs\/biome\":.*)/g,
+        replace: '',
+      },
+    ],
+  });
+
+  const packageJsonPath = path.join(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  packageJson.devDependencies['@biomejs/biome'] = '1.9.4';
+  fs.writeFileSync(
+    packageJsonPath,
+    JSON.stringify(packageJson, null, 2) + '\n',
+    'utf-8',
+  );
+
+  const biomeConfig = {
+    $schema: 'https://biomejs.dev/schemas/1.9.4/schema.json',
+    organizeImports: {
+      enabled: true,
+    },
+    formatter: {
+      enabled: true,
+      indentStyle: 'space',
+      indentWidth: 2,
+      lineWidth: 100,
+      formatWithErrors: false,
+    },
+    linter: {
+      enabled: true,
+      rules: {
+        recommended: true,
+        correctness: {
+          noUnusedVariables: 'error',
+        },
+        style: {
+          noNonNullAssertion: 'off',
+          useSingleVarDeclarator: 'off',
+        },
+        suspicious: {
+          noExplicitAny: 'off',
+          noConfusingVoidType: 'off',
+        },
+      },
+    },
+    javascript: {
+      formatter: {
+        quoteStyle: 'single',
+        trailingCommas: 'all',
+      },
+    },
+    files: {
+      ignore: ['dist', 'coverage', 'node_modules'],
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(process.cwd(), 'biome.json'),
+    JSON.stringify(biomeConfig, null, 2) + '\n',
+    'utf-8',
+  );
+
+  const eslintConfigPath = path.join(process.cwd(), 'eslint.config.mjs');
+  if (fs.existsSync(eslintConfigPath)) {
+    fs.rmSync(eslintConfigPath, { force: true });
+  }
+
+  const prettierRcPath = path.join(process.cwd(), '.prettierrc');
+  if (fs.existsSync(prettierRcPath)) {
+    fs.rmSync(prettierRcPath, { force: true });
+  }
+
+  replace({
+    path: path.join(process.cwd(), '.husky', 'pre-commit'),
+    actions: [
+      {
+        find: /npm run lint/g,
+        replace: 'npx biome check src/ test/ .install-scripts/',
+      },
+    ],
+  });
+};
+
+export default removeEslintPrettier;

--- a/.install-scripts/scripts/remove-eslint-prettier.ts
+++ b/.install-scripts/scripts/remove-eslint-prettier.ts
@@ -99,6 +99,7 @@ const removeEslintPrettier = () => {
         style: {
           noNonNullAssertion: 'off',
           useSingleVarDeclarator: 'off',
+          useImportType: 'off',
         },
         suspicious: {
           noExplicitAny: 'off',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postadd:property:to-document": "npm run lint -- --fix",
     "add:property:to-relational": "hygen property add-to-relational",
     "postadd:property:to-relational": "npm run lint -- --fix",
-    "app:config": "ts-node -r tsconfig-paths/register ./.install-scripts/index.ts && npm install && npm run lint -- --fix",
+    "app:config": "ts-node -r tsconfig-paths/register ./.install-scripts/index.ts && npm install && npm run lint",
     "seed:run:relational": "ts-node -r tsconfig-paths/register ./src/database/seeds/relational/run-seed.ts",
     "seed:run:document": "ts-node -r tsconfig-paths/register ./src/database/seeds/document/run-seed.ts",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
## Summary

Add a new prompt to the interactive install script (`npm run app:config`) that lets users choose between **ESLint & Prettier** (default) or **Biome.js** as their linter and formatter.

## Changes

### New interactive prompt
```
Which linter and formatter do you want to use?
  > ESLint & Prettier (default)
  > Biome
```

### When Biome is selected, the script:

- **Creates** `biome.json` with:
  - Recommended rules enabled
  - Single quotes, trailing commas (mirrors existing Prettier config)
  - `noUnusedVariables: error` (mirrors existing ESLint rule)
  - `noExplicitAny: off`, `noNonNullAssertion: off` (mirrors existing ESLint overrides)
  - `useImportType: off` — critical for NestJS decorator metadata reflection
- **Removes** `eslint.config.mjs` and `.prettierrc`
- **Removes** devDependencies: `eslint`, `prettier`, `@typescript-eslint/*`, `eslint-config-prettier`, `eslint-plugin-prettier`, `@eslint/*`, `globals`
- **Adds** `@biomejs/biome` devDependency
- **Updates** `lint` → `biome check --write src/ test/ .install-scripts/`
- **Updates** `format` → `biome format --write src/ test/ .install-scripts/`
- **Updates** `.husky/pre-commit` → `npx biome check ...` instead of `npm run lint`
- **Removes** `--fix` from post-generate scripts (biome uses `--write`)

## Why

Biome is significantly faster than ESLint + Prettier (10-100x), has a single configuration file, and handles both linting and formatting. This gives users the choice without breaking existing workflows.
